### PR TITLE
ar(fix) ThunderBird calendar slows after editing one CalDav entry: draft: watch events prop drain

### DIFF
--- a/src/Qalendar.vue
+++ b/src/Qalendar.vue
@@ -135,6 +135,10 @@ export default defineComponent({
       type: Array as PropType<eventInterface[]>,
       default: () => [],
     },
+    updatedEvents: {
+      type: Array as PropType<eventInterface[]>,
+      default: () => [],
+    },
     selectedDate: {
       type: Date,
       default: new Date(),
@@ -184,30 +188,16 @@ export default defineComponent({
       ErrorsHelper: Errors,
     };
   },
-  computed:{
+  computed: {
     enhancedConfig(): configInterface {
       return { ...this.config, isSmall: this.isSmall }
+    },
+    updatedEvents(): PropType<eventInterface[]>{
+      return { ...this.events }
     }
   },
 
   watch: {
-    events: {
-      deep: true,
-      handler(newVal, oldVal) {
-        // The check on strict equality as primitive values is needed,
-        // since we do not want to trigger a rerender on event-was-resized
-        if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
-          this.eventsDataProperty = newVal;
-          this.eventRenderingKey = this.eventRenderingKey + 1;
-        }
-
-        if (this.config.isSilent) return;
-
-        this.events.forEach((e) => this.ErrorsHelper.checkEventProperties(e));
-      },
-      immediate: true,
-    },
-
     config: {
       deep: true,
       handler(value: configInterface) {
@@ -325,8 +315,12 @@ export default defineComponent({
       const newEvents = this.eventsDataProperty.filter(
         (e) => e.id !== calendarEvent.id
       );
+
       this.eventsDataProperty = [calendarEvent, ...newEvents];
       this.$emit(`event-was-${eventType}`, calendarEvent);
+
+      if (this.config.isSilent) return;
+      newEvents.forEach((e) => this.ErrorsHelper.checkEventProperties(e));
     },
 
     setTimePointsFromDayBoundary(boundary: number) {


### PR DESCRIPTION
**Context (REQUIRED):**

**This PR is being opened without local testing (to draft and test later, or for someone else to pickup with some reference).**

Other than limiting the amount of events rendered by the returned CalDav source, another approach to solving this is to memoize the events as they're first received or locally stored, then use a SubPub pattern to trigger the update of the event metadata on-demand (user dragged, user resized event, user actually edited the event content), to re-render only the respective event.

- AppleOS ThunderBird (Firefox)
- 128.6.0esr 20250107005646
- latest

**Describe the bug (REQUIRED)**

Currently, it seems like by `watching` the `events` prop, any update (visibility toggle, unsubscribe from calendar, update event details, etc.) triggers a re-render of the entire `events` prop dependency tree (whole calendar, every view, every mode, every event, etc).

When manipulating an event or any calendar with multiple events repeated to infinity, it creates a drain of time complexity that crashes Thunderbird entirely. 

**To Reproduce**

Steps to reproduce the behavior:

1. Add a few CalDav Calendars (e.g. 4)
2. Add a few daily events (e.g. 10 events everyday at different times)
3. Try to:
- Edit one event;
- Delete a recurring event;
- Hide/Show calendar visibility;
- Unsubscribe from calendars;
5. At any, if not all, if as in my local environment, Thunderbird should freeze, even if temporarily, although in my Macbook, it usually crashes Thunderbird entirely.

**Expected behavior**

I modify one event.
UI shows the updated data immediately (re-renders only the modified event).
I take any other action in the calendar and its events (except a global update e.g. color).
Not every event should re-render, but only the affected ones.

**Screenshots**

- e.g. I've just hidden the visibility of 1 out of 4 CalDav calendars, with a few dozen recurring events only, and it crashed the app (frozen for over 3 minutes, now unresponsive, might resolve after a few more minutes).

https://github.com/user-attachments/assets/a787f090-0506-4381-a106-43f3c209319d

**Additional context**

This is my first PR with Thunderbird, it's under-tested, and I ask to pardon any imperfections. It's late here for me to make sure this PR works (setup local environment), but it might help shed some light to someone else with all the toolkit at hand.

## How to test this PR**. 

**This PR is being opened without local testing (to draft and test later, or for someone else to pickup with some reference).**

